### PR TITLE
Add 'validate' alias for 'ok'

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ and you can verify this by using a `Json.Decode.Pipeline`-like api.
 ```elm
      validator : Validator String Model VerifiedModel
      validator =
-        Verify.ok VerifiedModel
+        validate VerifiedModel
             |> keep .id
             |> verify .firstName (Maybe.Verify.isJust "no first name")
             |> verify .lastName (Maybe.Verify.isJust"no last name")


### PR DESCRIPTION
With docs based on the Json.Decode.Pipeline docs for the 'decode' alias which fills a similar roll.

The other doc examples have been updated to use it instead of Verify.ok at the start of the pipeline.